### PR TITLE
Use variable timeouts

### DIFF
--- a/lib/orchestrator/models/pipeline_client.rb
+++ b/lib/orchestrator/models/pipeline_client.rb
@@ -60,7 +60,9 @@ class PipelineClient
       # container_version: "sha-122a036658c815c2024c604046692adc4c23d5c1",
     }
     timeout = Orchestrator::TRACKS[track_slug][:timeout]
-    send_recv(params, timeout)
+    params[:execution_timeout] = timeout / 1000
+    client_timeout = timeout + 2000
+    send_recv(params, client_timeout)
   end
 
   def build_container(track_slug, container_type, reference)

--- a/test/pipeline_client_test.rb
+++ b/test/pipeline_client_test.rb
@@ -18,6 +18,7 @@ module Orchestrator
           exercise_slug: exercise_slug,
           s3_uri: s3_uri,
           container_version: container_version,
+          execution_timeout: 3
         }
         recv_result = 1
         result = {"some" => "response"}
@@ -32,8 +33,8 @@ module Orchestrator
 
         zmq_socket = mock
         zmq_socket.expects(:linger=).with(1)
-        zmq_socket.expects(:linger=).with(1500)
-        zmq_socket.expects(:rcvtimeo=).with(3000)
+        zmq_socket.expects(:linger=).with(2500)
+        zmq_socket.expects(:rcvtimeo=).with(5000)
         zmq_socket.expects(:connect).with(address)
         zmq_socket.expects(:send_message).with(message)
         zmq_socket.expects(:recv_message).returns(response_message)
@@ -57,5 +58,3 @@ module Orchestrator
     end
   end
 end
-
-


### PR DESCRIPTION
This PR sends the track specific timeout into the container runtime. The overall client timeout is also increased by 2 seconds so that it doesn't prematurely close.